### PR TITLE
Add recursive option in watch func and some useful field in kvpair

### DIFF
--- a/store/boltdb/boltdb.go
+++ b/store/boltdb/boltdb.go
@@ -464,7 +464,7 @@ func (b *BoltDB) NewLock(key string, options *store.LockOptions) (store.Locker, 
 }
 
 // Watch has to implemented at the library level since its not supported by BoltDB
-func (b *BoltDB) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
+func (b *BoltDB) Watch(key string, stopCh <-chan struct{}, recursive bool) (<-chan *store.KVPair, error) {
 	return nil, store.ErrCallNotSupported
 }
 

--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -276,7 +276,7 @@ func (s *Consul) DeleteTree(directory string) error {
 // on errors. Upon creation, the current value will first
 // be sent to the channel. Providing a non-nil stopCh can
 // be used to stop watching.
-func (s *Consul) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
+func (s *Consul) Watch(key string, stopCh <-chan struct{}, recursive bool) (<-chan *store.KVPair, error) {
 	kv := s.client.KV()
 	watchCh := make(chan *store.KVPair)
 

--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -232,8 +232,8 @@ func (s *Etcd) Exists(key string) (bool, error) {
 // on errors. Upon creation, the current value will first
 // be sent to the channel. Providing a non-nil stopCh can
 // be used to stop watching.
-func (s *Etcd) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
-	opts := &etcd.WatcherOptions{Recursive: false}
+func (s *Etcd) Watch(key string, stopCh <-chan struct{}, recursive bool) (<-chan *store.KVPair, error) {
+	opts := &etcd.WatcherOptions{Recursive: recursive}
 	watcher := s.client.Watcher(s.normalize(key), opts)
 
 	// watchCh is sending back events to the caller
@@ -269,6 +269,8 @@ func (s *Etcd) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, 
 				Key:       key,
 				Value:     []byte(result.Node.Value),
 				LastIndex: result.Node.ModifiedIndex,
+				Action:    result.Action,
+				IsDir:	   result.Node.Dir,
 			}
 		}
 	}()

--- a/store/mock/mock.go
+++ b/store/mock/mock.go
@@ -49,7 +49,7 @@ func (s *Mock) Exists(key string) (bool, error) {
 }
 
 // Watch mock
-func (s *Mock) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
+func (s *Mock) Watch(key string, stopCh <-chan struct{}, recursive bool) (<-chan *store.KVPair, error) {
 	args := s.Mock.Called(key, stopCh)
 	return args.Get(0).(<-chan *store.KVPair), args.Error(1)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -76,7 +76,7 @@ type Store interface {
 	Exists(key string) (bool, error)
 
 	// Watch for changes on a key
-	Watch(key string, stopCh <-chan struct{}) (<-chan *KVPair, error)
+	Watch(key string, stopCh <-chan struct{}, recursive bool) (<-chan *KVPair, error)
 
 	// WatchTree watches for changes on child nodes under
 	// a given directory
@@ -109,6 +109,8 @@ type KVPair struct {
 	Key       string
 	Value     []byte
 	LastIndex uint64
+	Action	  string
+	IsDir	  bool
 }
 
 // WriteOptions contains optional request parameters

--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -154,7 +154,7 @@ func (s *Zookeeper) Exists(key string) (bool, error) {
 // on errors. Upon creation, the current value will first
 // be sent to the channel. Providing a non-nil stopCh can
 // be used to stop watching.
-func (s *Zookeeper) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
+func (s *Zookeeper) Watch(key string, stopCh <-chan struct{}, recursive bool) (<-chan *store.KVPair, error) {
 	// Get the key first
 	pair, err := s.Get(key)
 	if err != nil {


### PR DESCRIPTION
  1. Add recursive option in watch func for ETCD
     - If recursive option isn't exist in watch(), we can not get last key
      which changed by etcd from parents directory.

  2. Add some useful field in kvpair struct
     - Action: It can describe event type when the watch event occurred.
     - IsDir: It can describe whether item is KEY or DIR.

Signed-off-by: Inju Song \<inju.song@navercorp.com\>